### PR TITLE
Fixed issue #3. Number of chars shown when highlighting

### DIFF
--- a/Jottey.ps1
+++ b/Jottey.ps1
@@ -100,10 +100,15 @@ function TextBoxType($Sender, $e) {
     Set-Content $global:InputFile $TextBox.Text
   }
 
-  $s = $TextBox.SelectionStart
-  $y = $TextBox.GetLineFromCharIndex($s) + 1
-  $x = $s - $TextBox.GetFirstCharIndexOfCurrentLine() + 1
-  $StatusBarPanel.Text = "Ln: $y, Col: $x"
+  if($TextBox.SelectionLength){
+    $StatusBarPanel.Text = "Chars: " + ($TextBox.SelectedText).Length
+  }
+  else{
+    $s = $TextBox.SelectionStart
+    $y = $TextBox.GetLineFromCharIndex($s) + 1
+    $x = ($s - $TextBox.GetFirstCharIndexOfCurrentLine() + 1)
+    $StatusBarPanel.Text = "Ln: $y, Col: $x"
+  }
 
 }
 


### PR DESCRIPTION
Fixing issue #3 by changing to the amount of selected characters when selecting text.

When the mouse click is released outside of the form the function is not called. This is already a bug and will need a new issue raising for it.